### PR TITLE
🎮 Initial mod implementation: Sleep in villagers' beds

### DIFF
--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -4,6 +4,7 @@ using StardewValley;
 using Microsoft.Xna.Framework;
 using StardewValley.Objects;
 using System.Collections.Generic;
+using System.Linq;  // Add this for Contains
 
 namespace StardewSleepover
 {
@@ -100,6 +101,26 @@ namespace StardewSleepover
                 ValidNames = new[] {"SamHouse"} 
             }},
             // Add mappings for each house...
+        };
+
+        private Dictionary<string, string> locationOwners = new Dictionary<string, string>
+        {
+            {"HaleyHouse", "Haley"},
+            {"SamHouse", "Sam"},
+            {"SebastianRoom", "Sebastian"},
+            {"CarpentersHouse", "Robin"},
+            {"ScienceHouse", "Maru"},
+            {"GeorgeHouse", "Alex"},
+            {"ArchaeologyHouse", "Penny"},
+            {"Trailer", "Pam"},
+            {"Manor", "Lewis"},
+            {"LeahHouse", "Leah"},
+            {"ElliottHouse", "Elliott"},
+            {"WizardHouse", "Wizard"},
+            {"HarveyRoom", "Harvey"},
+            {"AnimalShop", "Marnie"},
+            {"Ranch", "Marnie"},
+            {"Saloon", "Gus"}
         };
 
         private string currentHouseOwner = null;
@@ -339,9 +360,25 @@ namespace StardewSleepover
             }
 
             // Check if we've warped into someone's house
-            if (e.NewLocation.Name == "HaleyHouse") currentHouseOwner = "Haley";
-            else if (e.NewLocation.Name == "SamHouse") currentHouseOwner = "Sam";
-            // ... add other house mappings
+            switch (e.NewLocation.Name)
+            {
+                case "HaleyHouse": currentHouseOwner = "Haley"; break;
+                case "SamHouse": currentHouseOwner = "Sam"; break;
+                case "SebastianRoom": currentHouseOwner = "Sebastian"; break;
+                case "CarpentersHouse": currentHouseOwner = "Robin"; break;
+                case "ScienceHouse": currentHouseOwner = "Maru"; break;
+                case "GeorgeHouse": currentHouseOwner = "Alex"; break;
+                case "ArchaeologyHouse": currentHouseOwner = "Penny"; break;
+                case "Trailer": currentHouseOwner = "Pam"; break;
+                case "Manor": currentHouseOwner = "Lewis"; break;
+                case "LeahHouse": currentHouseOwner = "Leah"; break;
+                case "ElliottHouse": currentHouseOwner = "Elliott"; break;
+                case "WizardHouse": currentHouseOwner = "Wizard"; break;
+                case "HarveyRoom": currentHouseOwner = "Harvey"; break;
+                case "AnimalShop":
+                case "Ranch": currentHouseOwner = "Marnie"; break;
+                case "Saloon": currentHouseOwner = "Gus"; break;
+            }
 
             if (currentHouseOwner != null)
             {

--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -1,0 +1,204 @@
+using StardewModdingAPI;
+using StardewModdingAPI.Events;
+using StardewValley;
+using Microsoft.Xna.Framework;
+using StardewValley.Objects;
+using System.Collections.Generic;
+
+namespace StardewSleepover
+{
+    public class ModEntry : Mod
+    {
+        private readonly int REQUIRED_HEARTS = 6;
+
+        private Dictionary<string, Rectangle> bedAreas = new Dictionary<string, Rectangle>
+        {
+            // Format: {"LocationName", new Rectangle(x, y, width, height)}
+            {"AnimalShop", new Rectangle(8, 4, 2, 3)},  // Marnie's bed area
+            {"Manor", new Rectangle(8, 5, 2, 3)},       // Lewis's bed area
+            // Add more bed areas...
+        };
+
+        public override void Entry(IModHelper helper)
+        {
+            helper.Events.Input.ButtonPressed += OnButtonPressed;
+            helper.Events.GameLoop.TimeChanged += OnTimeChanged;
+            helper.Events.Display.RenderedWorld += OnRenderedWorld;
+        }
+
+        private void OnButtonPressed(object sender, ButtonPressedEventArgs e)
+        {
+            if (!Context.IsWorldReady || !Context.IsPlayerFree)
+                return;
+
+            GameLocation location = Game1.currentLocation;
+            if (location == null || location.IsFarm)
+                return;
+
+            // Only check if the player pressed the action button
+            if (!e.Button.IsActionButton())
+                return;
+
+            Vector2 playerTile = Game1.player.Position / 64f;
+            Monitor.Log($"Player at: {playerTile} in {location.Name}", LogLevel.Debug);
+
+            // Check if player is in a bed area
+            if (bedAreas.TryGetValue(location.Name, out Rectangle bedArea))
+            {
+                if (bedArea.Contains((int)playerTile.X, (int)playerTile.Y))
+                {
+                    Monitor.Log($"Found bed area in {location.Name}!", LogLevel.Debug);
+                    HandleBedInteraction(location, new Vector2(bedArea.X, bedArea.Y));
+                    return;
+                }
+            }
+        }
+
+        private bool IsBed(Furniture furniture)
+        {
+            string furnitureName = furniture.Name.ToLower();
+            bool isBed = furnitureName.Contains("bed") || 
+                        furnitureName.Contains("single") ||
+                        furnitureName.Contains("double") ||
+                        furnitureName.Contains("king") ||
+                        furnitureName.Contains("queen") ||
+                        furniture is BedFurniture;
+                        
+            Monitor.Log($"Checking furniture '{furnitureName}' - Is bed? {isBed}", LogLevel.Debug);
+            return isBed;
+        }
+
+        private void OnTimeChanged(object sender, TimeChangedEventArgs e)
+        {
+            // Wake up if it's morning
+            if (Game1.player.isInBed.Value && Game1.timeOfDay == 600)
+            {
+                Game1.player.isInBed.Value = false;
+                Game1.currentLocation = Game1.getLocationFromName("FarmHouse");
+                Game1.player.Position = new Vector2(Game1.player.Position.X, Game1.player.Position.Y);
+            }
+        }
+
+        private void HandleBedInteraction(GameLocation location, Vector2 bedPosition)
+        {
+            // Get the owner of the room/bed
+            string owner = GetBedOwner(location);
+            if (string.IsNullOrEmpty(owner))
+            {
+                Monitor.Log("This bed doesn't belong to anyone.", LogLevel.Debug);
+                Game1.chatBox?.addMessage("This bed doesn't belong to anyone.", Color.Red);
+                return;
+            }
+
+            // Check friendship level
+            if (!Game1.player.friendshipData.ContainsKey(owner))
+            {
+                string message = $"You don't know {owner} well enough to sleep here.";
+                Game1.addHUDMessage(new HUDMessage(message, HUDMessage.error_type));
+                Game1.chatBox?.addMessage(message, Color.Red);
+                return;
+            }
+
+            int hearts = Game1.player.friendshipData[owner].Points / 250;
+            if (hearts < REQUIRED_HEARTS)
+            {
+                string message = $"You need {REQUIRED_HEARTS} hearts with {owner} to sleep here.";
+                Game1.addHUDMessage(new HUDMessage(message, HUDMessage.error_type));
+                Game1.chatBox?.addMessage(message, Color.Red);
+                return;
+            }
+
+            // Allow sleeping
+            if (Game1.timeOfDay >= 2000 || (Game1.isRaining && Game1.timeOfDay >= 1800))
+            {
+                Game1.chatBox?.addMessage($"Sleeping in {owner}'s bed...", Color.Green);
+                
+                // Set bed position for proper animation
+                Game1.player.Position = new Vector2(bedPosition.X * 64, bedPosition.Y * 64);
+                
+                // Show the sleep dialog like the normal bed does
+                Game1.currentLocation.createQuestionDialogue(
+                    "Do you want to go to sleep for the night?",
+                    Game1.currentLocation.createYesNoResponses(),
+                    (who, whichAnswer) =>
+                    {
+                        if (whichAnswer == "Yes")
+                        {
+                            Game1.player.isInBed.Value = true;
+                            Game1.player.doEmote(24);
+                            Game1.NewDay(600f);
+                        }
+                        Game1.activeClickableMenu = null;
+                    }
+                );
+            }
+            else
+            {
+                Game1.addHUDMessage(new HUDMessage("You can only sleep after 8:00 PM (or 6:00 PM if raining).", HUDMessage.error_type));
+            }
+        }
+
+        private string GetBedOwner(GameLocation location)
+        {
+            // Map locations to their owners
+            Dictionary<string, string> locationOwners = new Dictionary<string, string>
+            {
+                {"HaleyHouse", "Haley"},
+                {"SamHouse", "Sam"},
+                {"SebastianRoom", "Sebastian"},
+                {"CarpentersHouse", "Robin"},
+                {"ScienceHouse", "Maru"},
+                {"JoshHouse", "Alex"},
+                {"ArchaeologyHouse", "Penny"},
+                {"Trailer", "Pam"},
+                {"Manor", "Lewis"},
+                {"LeahHouse", "Leah"},
+                {"ElliottHouse", "Elliott"},
+                {"WizardHouse", "Wizard"},
+                {"HarveyRoom", "Harvey"},
+                {"AnimalShop", "Marnie"},
+                {"Ranch", "Marnie"}
+            };
+
+            Monitor.Log($"Checking location: {location.Name}", LogLevel.Debug);
+            if (locationOwners.TryGetValue(location.Name, out string owner))
+                return owner;
+
+            return null;
+        }
+
+        private void OnRenderedWorld(object sender, RenderedWorldEventArgs e)
+        {
+            if (!Context.IsWorldReady)
+                return;
+
+            GameLocation location = Game1.currentLocation;
+            if (bedAreas.TryGetValue(location.Name, out Rectangle bedArea))
+            {
+                // Convert tile coordinates to screen coordinates
+                Vector2 screenPos = Game1.GlobalToLocal(new Vector2(bedArea.X * 64, bedArea.Y * 64));
+                Rectangle screenRect = new Rectangle(
+                    (int)screenPos.X,
+                    (int)screenPos.Y,
+                    bedArea.Width * 64,
+                    bedArea.Height * 64
+                );
+
+                // Draw a semi-transparent rectangle around the bed area
+                e.SpriteBatch.Draw(
+                    Game1.staminaRect,  // Using the game's white pixel texture
+                    screenRect,
+                    Color.Red * 0.3f    // Semi-transparent red
+                );
+
+                // Draw the coordinates as text for debugging
+                e.SpriteBatch.DrawString(
+                    Game1.smallFont,
+                    $"Bed Area: {bedArea}",
+                    new Vector2(screenPos.X, screenPos.Y - 20),
+                    Color.Yellow
+                );
+            }
+        }
+    }
+}

--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -29,7 +29,7 @@ namespace StardewSleepover
         {
             {"AnimalShop", new List<BedInfo> {
                 new BedInfo { Area = new Rectangle(12, 4, 2, 3), Owner = "Marnie" },  // Marnie's bed
-                new BedInfo { Area = new Rectangle(23, 3, 3, 3), Owner = "Shane" }    // Shane's bed
+                new BedInfo { Area = new Rectangle(25, 4, 3, 1), Owner = "Shane" }    // Shane's bed: around 25-27 X, 4 Y
             }},
             {"Manor", new List<BedInfo> {
                 new BedInfo { Area = new Rectangle(24, 5, 3, 2), Owner = "Lewis" }    // Lewis's bed: 24,5 to 26,6

--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -15,6 +15,7 @@ namespace StardewSleepover
         {
             public Rectangle Area { get; set; }
             public string Owner { get; set; }
+            public string SecondaryOwner { get; set; }  // For couples' beds
         }
 
         private Dictionary<string, List<BedInfo>> bedAreas = new Dictionary<string, List<BedInfo>>
@@ -24,7 +25,61 @@ namespace StardewSleepover
                 new BedInfo { Area = new Rectangle(23, 3, 3, 3), Owner = "Shane" }    // Shane's bed
             }},
             {"Manor", new List<BedInfo> {
-                new BedInfo { Area = new Rectangle(8, 5, 2, 3), Owner = "Lewis" }     // Lewis's bed
+                new BedInfo { Area = new Rectangle(24, 5, 3, 2), Owner = "Lewis" }    // Lewis's bed: 24,5 to 26,6
+            }},
+            {"LeahHouse", new List<BedInfo> {
+                new BedInfo { Area = new Rectangle(9, 4, 3, 1), Owner = "Leah" }      // Leah's bed: 9,4 to 11,4
+            }},
+            {"SamHouse", new List<BedInfo> {
+                new BedInfo { Area = new Rectangle(24, 7, 3, 2), Owner = "Sam" },     // Sam's bed: 24,7 to 26,8
+                new BedInfo { 
+                    Area = new Rectangle(28, 4, 4, 2), 
+                    Owner = "Jodi",
+                    SecondaryOwner = "Kent"
+                }     // Jodi & Kent's bed: 28,4 to 31,5
+            }},
+            {"SeedShop", new List<BedInfo> {
+                new BedInfo { Area = new Rectangle(1, 5, 2, 2), Owner = "Abigail" },   // Abigail's bed: 1,5 to 2,6
+                new BedInfo { 
+                    Area = new Rectangle(16, 3, 3, 2), 
+                    Owner = "Caroline",
+                    SecondaryOwner = "Pierre"
+                }  // Pierre & Caroline's bed: 16,3 to 18,4
+            }},
+            {"GeorgeHouse", new List<BedInfo> {
+                new BedInfo { Area = new Rectangle(23, 3, 3, 3), Owner = "Alex" },     // Alex's bed: 23,3 to 25,5
+                new BedInfo {
+                    Area = new Rectangle(9, 3, 3, 2),
+                    Owner = "George",
+                    SecondaryOwner = "Evelyn"
+                }      // George & Evelyn's bed
+            }},
+            {"Trailer", new List<BedInfo> {
+                new BedInfo { Area = new Rectangle(8, 10, 3, 3), Owner = "Pam" }      // Pam's bed: 8,10 to 10,12
+            }},
+            {"ElliottHouse", new List<BedInfo> {
+                new BedInfo { Area = new Rectangle(17, 5, 2, 2), Owner = "Elliott" }  // Elliott's bed: 17,5 to 18,6
+            }},
+            {"HaleyHouse", new List<BedInfo> {
+                new BedInfo { Area = new Rectangle(4, 4, 3, 2), Owner = "Haley" },    // Haley's bed: 4,4 to 6,5
+                new BedInfo { Area = new Rectangle(22, 3, 3, 2), Owner = "Emily" }    // Emily's bed: 22,3 to 24,4
+            }},
+            {"Saloon", new List<BedInfo> {
+                new BedInfo { Area = new Rectangle(16, 3, 3, 2), Owner = "Gus" }      // Gus's bed: 16,3 to 18,4
+            }},
+            {"HarveyRoom", new List<BedInfo> {
+                new BedInfo { Area = new Rectangle(15, 5, 3, 2), Owner = "Harvey" }   // Harvey's bed: 15,5 to 17,6
+            }},
+            {"SebastianRoom", new List<BedInfo> {
+                new BedInfo { Area = new Rectangle(16, 8, 3, 3), Owner = "Sebastian" } // Sebastian's bed: 16,8 to 18,10
+            }},
+            {"ScienceHouse", new List<BedInfo> {
+                new BedInfo { 
+                    Area = new Rectangle(13, 3, 4, 2), 
+                    Owner = "Robin",
+                    SecondaryOwner = "Demetrius"
+                },  // Robin & Demetrius's bed: 13,3 to 16,4
+                new BedInfo { Area = new Rectangle(2, 3, 2, 2), Owner = "Maru" }      // Maru's bed: 2,3 to 3,4
             }}
         };
 
@@ -164,7 +219,7 @@ namespace StardewSleepover
                 {"SebastianRoom", "Sebastian"},
                 {"CarpentersHouse", "Robin"},
                 {"ScienceHouse", "Maru"},
-                {"JoshHouse", "Alex"},
+                {"GeorgeHouse", "Alex"},
                 {"ArchaeologyHouse", "Penny"},
                 {"Trailer", "Pam"},
                 {"Manor", "Lewis"},
@@ -173,7 +228,8 @@ namespace StardewSleepover
                 {"WizardHouse", "Wizard"},
                 {"HarveyRoom", "Harvey"},
                 {"AnimalShop", "Marnie"},
-                {"Ranch", "Marnie"}
+                {"Ranch", "Marnie"},
+                {"Saloon", "Gus"}
             };
 
             Monitor.Log($"Checking location: {location.Name}", LogLevel.Debug);

--- a/README.md
+++ b/README.md
@@ -1,0 +1,76 @@
+# 🛏️ Stardew Sleepover
+
+> Sleep in your friends' beds! (With permission, of course - 6+ hearts required)
+
+A Stardew Valley mod that lets you have sleepovers at NPCs' houses. Once you've built up enough friendship with a villager, you can sleep in their bed just like your own.
+
+## ✨ Features
+- Sleep in any NPC's bed once you have 6+ hearts with them
+- Works with all villager houses
+- Respects marriage and relationships (need hearts with both partners for shared beds)
+- Normal sleep mechanics (save game, restore energy, etc.)
+- Can sleep from 8:00 PM (or 6:00 PM if raining)
+
+## 🎮 Installation
+1. Install [SMAPI](https://smapi.io/)
+2. Download the latest release
+3. Extract to your `Stardew Valley/Mods` folder
+4. Run the game using SMAPI
+
+## 🔧 Development
+
+### Prerequisites
+- SMAPI
+- .NET 6.0 SDK
+- Visual Studio/VS Code (optional)
+
+### Quick Start
+#### Clone the repository
+```bash
+git clone https://github.com/ka1ne/StardewSleepover.git
+```
+
+#### Build the mod
+```bash
+dotnet build
+```
+The mod will automatically be copied to your Stardew Valley Mods folder thanks to SMAPI's ModBuildConfig.
+
+### Hot Reloading
+While developing, you can:
+1. Keep the game running
+2. Make code changes
+3. Run `dotnet build`
+4. Try `reload_i18n` in SMAPI console (`~` key)
+5. If changes don't appear, restart the game
+
+Note: Most code changes require a game restart, but some content can be hot reloaded.
+
+### Debug Features
+The mod includes several development aids:
+- 🟥 Visual bed area rectangles (red semi-transparent boxes)
+- 📝 Detailed warp tracking logs in SMAPI console
+- 🎯 `sleepover_debug` command for checking tile coordinates
+- 📊 On-screen debug text showing bed areas and coordinates
+
+### Project Structure
+```
+StardewSleepover/
+├── ModEntry.cs # Main mod code
+├── manifest.json # Mod metadata
+└── StardewSleepover.csproj # Project configuration
+```
+
+## 🤝 Contributing
+Contributions are welcome! Feel free to:
+- Report bugs
+- Suggest features
+- Submit pull requests
+
+## 📝 License
+[MIT License](LICENSE)
+
+## 🙏 Acknowledgments
+- ConcernedApe for Stardew Valley
+- Pathoschild for SMAPI
+- All the villagers for letting us sleep in their beds

--- a/StardewSleepover.csproj
+++ b/StardewSleepover.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <GamePath>C:\Program Files (x86)\Steam\steamapps\common\Stardew Valley</GamePath>
+    <EnableHarmony>false</EnableHarmony>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.1" />
+  </ItemGroup>
+</Project> 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,10 @@
+{
+  "Name": "Stardew Sleepover",
+  "Author": "ka1ne",
+  "Version": "1.0.0",
+  "Description": "Sleep in NPCs' beds when you have 6+ hearts with them",
+  "UniqueID": "ka1ne.StardewSleepover",
+  "EntryDll": "StardewSleepover.dll",
+  "MinimumApiVersion": "4.0.0",
+  "UpdateKeys": []
+} 


### PR DESCRIPTION
Initial implementation of the Stardew Sleepover mod, allowing players to sleep in villagers' beds with sufficient friendship.

### Core Features
- Sleep in any NPC's bed with 6+ hearts friendship
- Support for single and couples' beds
- Proper sleep mechanics (save, energy restore, time skip)
- Sleep time restrictions (8:00 PM or 6:00 PM if raining)

### Bed Mapping
Added bed coordinates for all villagers:
- Marnie & Shane (AnimalShop)
- Lewis (Manor)
- Leah (LeahHouse)
- Sam & Jodi/Kent (SamHouse)
- Abigail & Caroline/Pierre (SeedShop)
- Alex & George/Evelyn (GeorgeHouse)
- Pam (Trailer)
- Elliott (ElliottHouse)
- Haley & Emily (HaleyHouse)
- Gus (Saloon)
- Harvey (HarveyRoom)
- Sebastian (SebastianRoom)
- Robin/Demetrius & Maru (ScienceHouse)

### Technical Implementation
- Bed area detection system
- House ownership tracking via warps
- Support for shared beds (requires hearts with both owners)
- Debug visualization and logging system

### Development Features
- Visual bed area debugging
- Warp tracking logs
- Tile coordinate debugging
- Hot reload support

### Documentation
- Comprehensive README
- Development setup guide
- Debug feature documentation
- Project structure documentation